### PR TITLE
parse empty lines and comments

### DIFF
--- a/bashlex/ast.py
+++ b/bashlex/ast.py
@@ -33,7 +33,9 @@ class nodevisitor(object):
 
     def visit(self, n):
         k = n.kind
-        if k == 'operator':
+        if k == 'newline':
+            self.visitnode(n)
+        elif k == 'operator':
             self._visitnode(n, n.op)
         elif k == 'list':
             dochild = self._visitnode(n, n.parts)
@@ -86,9 +88,10 @@ class nodevisitor(object):
         elif k in ('parameter', 'tilde', 'heredoc'):
             self._visitnode(n, n.value)
         elif k in ('commandsubstitution', 'processsubstitution'):
-            dochild = self._visitnode(n, n.command)
+            dochild = self._visitnode(n, n.parts)
             if dochild is None or dochild:
-                self.visit(n.command)
+                for child in n.parts:
+                    self.visit(child)
         else:
             raise ValueError('unknown node kind %r' % k)
         self.visitnodeend(n)

--- a/bashlex/parser.py
+++ b/bashlex/parser.py
@@ -26,6 +26,9 @@ def p_inputunit(p):
         # accept right here in case the input contains more lines that are
         # not part of the current command
         p.accept()
+    if p.slice[1].ttype == tokenizer.tokentype.NEWLINE:
+        p[0] = ast.node(kind='newline', pos=(p.lexpos(1), p.lexpos(1)))
+        p.accept()
 
 def p_word_list(p):
     '''word_list : WORD
@@ -209,7 +212,7 @@ def p_shell_command(p):
         p[0] = p[1]
     else:
         # while or until
-        assert p[2].kind == 'list'
+        # assert p[2].kind == 'list'
 
         parts = _makeparts(p)
         kind = parts[0].word
@@ -550,6 +553,7 @@ yaccparser.action[133]['RIGHT_PAREN'] = -154
 for tt in tokenizer.tokentype:
     yaccparser.action[62][tt.name] = -1
     yaccparser.action[63][tt.name] = -141
+    yaccparser.action[8][tt.name] = -2
 
 def parsesingle(s, strictmode=True, expansionlimit=None, convertpos=False):
     '''like parse, but only consumes a single top level node, e.g. parsing
@@ -608,6 +612,7 @@ def parse(s, strictmode=True, expansionlimit=None, convertpos=False):
         for tree in parts:
             ast.posconverter(s).visit(tree)
 
+    parts = filter(lambda x: x.kind != 'newline', parts)
     return parts
 
 class _parser(object):

--- a/bashlex/subst.py
+++ b/bashlex/subst.py
@@ -25,7 +25,7 @@ def _recursiveparse(parserobj, base, sindex, tokenizerargs=None):
     endp = node.pos[1]
     _adjustpositions(node, sindex, len(base))
 
-    return node, endp
+    return node, endp, p.tok._current_token.nopos()
 
 def _parsedolparen(parserobj, base, sindex):
     copiedps = copy.copy(parserobj.parserstate)
@@ -33,33 +33,44 @@ def _parsedolparen(parserobj, base, sindex):
     copiedps.add(flags.parser.EOFTOKEN)
     string = base[sindex:]
 
-    tokenizerargs = {'eoftoken' : tokenizer.token(tokenizer.tokentype.RIGHT_PAREN, ')'),
+    eoftoken = tokenizer.token(tokenizer.tokentype.RIGHT_PAREN, ')')
+    tokenizerargs = {'eoftoken' : eoftoken,
                      'parserstate' : copiedps,
                      'lastreadtoken' : parserobj.tok._last_read_token,
                      'tokenbeforethat' : parserobj.tok._token_before_that,
                      'twotokensago' : parserobj.tok._two_tokens_ago}
 
-    node, endp = _recursiveparse(parserobj, base, sindex, tokenizerargs)
+    nodes = []
+    node, endp, token = _recursiveparse(parserobj, base, sindex, dict(tokenizerargs))
+    nodes.append(node)
+    while sindex + endp < len(base) and token != eoftoken:
+        while base[sindex+endp].isspace():
+            endp += 1
+            continue
+        node, endpp, token = _recursiveparse(parserobj, base, sindex + endp, dict(tokenizerargs))
+        nodes.append(node)
+        endp += endpp
+
 
     if string[endp] != ')':
         while endp > 0 and string[endp-1] == '\n':
             endp -= 1
 
-    return node, sindex + endp
+    return nodes, sindex + endp
 
 def _extractcommandsubst(parserobj, string, sindex, sxcommand=False):
     if string[sindex] == '(':
         raise NotImplementedError('arithmetic expansion')
         #return _extractdelimitedstring(parserobj, string, sindex, '$(', '(', '(', sxcommand=True)
     else:
-        node, si = _parsedolparen(parserobj, string, sindex)
+        nodes, si = _parsedolparen(parserobj, string, sindex)
         si += 1
-        return ast.node(kind='commandsubstitution', command=node, pos=(sindex-2, si)), si
+        return ast.node(kind='commandsubstitution', parts=nodes, pos=(sindex-2, si)), si
 
 def _extractprocesssubst(parserobj, string, sindex):
     #return _extractdelimitedstring(tok, string, sindex, starter, '(', ')', sxcommand=True)
-    node, si = _parsedolparen(parserobj, string, sindex)
-    return node, si + 1
+    nodes, si = _parsedolparen(parserobj, string, sindex)
+    return nodes, si + 1
 
 #def _extractdelimitedstring(parserobj, string, sindex, opener, altopener, closer,
 #                            sxcommand=False):
@@ -221,9 +232,9 @@ def _expandwordinternal(parserobj, wordtoken, qheredocument, qdoublequotes, quot
             else:
                 tindex = sindex[0] + 1
 
-                node, sindex[0] = _extractprocesssubst(parserobj, string, tindex)
+                nodes, sindex[0] = _extractprocesssubst(parserobj, string, tindex)
 
-                parts.append(ast.node(kind='processsubstitution', command=node,
+                parts.append(ast.node(kind='processsubstitution', parts=nodes,
                                       pos=(tindex - 2, sindex[0])))
                 istring += string[tindex - 2:sindex[0]]
                 # goto dollar_add_string
@@ -289,7 +300,8 @@ def _expandwordinternal(parserobj, wordtoken, qheredocument, qdoublequotes, quot
                         sindex[0] = x
 
                         word = string[tindex+1:sindex[0]]
-                        command, ttindex = _recursiveparse(parserobj, word, 0)
+                        # FIXME: handle new lines
+                        command, ttindex, _ = _recursiveparse(parserobj, word, 0)
                         _adjustpositions(command, tindex+1, len(string))
                         ttindex += 1 # ttindex is on the closing char
 
@@ -298,7 +310,7 @@ def _expandwordinternal(parserobj, wordtoken, qheredocument, qdoublequotes, quot
                         sindex[0] += 1
 
                         node = ast.node(kind='commandsubstitution',
-                                        command=command,
+                                        parts=[command],
                                         pos=(tindex, sindex[0]))
                         parts.append(node)
                         istring += string[tindex:sindex[0]]

--- a/bashlex/tokenizer.py
+++ b/bashlex/tokenizer.py
@@ -168,6 +168,9 @@ class token(object):
     def __nonzero__(self):
         return not (self.ttype is None and self.value is None)
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __eq__(self, other):
         return isinstance(other, token) and (self.type == other.type and
                                              self.value == other.value and

--- a/tests/test-parser.py
+++ b/tests/test-parser.py
@@ -67,11 +67,11 @@ def compoundnode(s, *parts, **kwargs):
     assert not kwargs
     return ast.node(kind='compound', s=s, list=list(parts), redirects=redirects)
 
-def procsubnode(s, command):
-    return ast.node(kind='processsubstitution', s=s, command=command)
+def procsubnode(s, parts):
+    return ast.node(kind='processsubstitution', s=s, parts=parts)
 
-def comsubnode(s, command):
-    return ast.node(kind='commandsubstitution', s=s, command=command)
+def comsubnode(s, parts):
+    return ast.node(kind='commandsubstitution', s=s, parts=parts)
 
 def ifnode(s, *parts):
     return ast.node(kind='if', parts=list(parts), s=s)
@@ -143,13 +143,30 @@ class test_parser(unittest.TestCase):
                   redirectnode('2>&1', 2, '>&', 1)))
 
     def test_multiline(self):
-        s = 'a\nb'
-        self.assertASTsEquals(s, [
-                              commandnode('a',
-                                wordnode('a')),
-                              commandnode('b',
-                                wordnode('b'))
-                              ])
+        for s in ('a\nb', 'a\n\nb'):
+            self.assertASTsEquals(s, [
+                                  commandnode('a',
+                                    wordnode('a')),
+                                  commandnode('b',
+                                    wordnode('b'))
+                                  ])
+
+        for comsub in ('$(b\nc)', '$(b\n\nc)'):
+            s = 'a %s' % comsub
+            self.assertASTsEquals(s, [
+                                    commandnode('a %s' % comsub,
+                                      wordnode('a'),
+                                      wordnode(comsub, comsub, [
+                                        comsubnode(comsub, [
+                                          commandnode('b', wordnode('b')),
+                                          commandnode('c', wordnode('c')),
+                                        ])
+                                      ]),
+                                    ),
+                                  ])
+
+        # TODO
+        s = 'a `b\nc`'
 
     def test_pipeline(self):
         s = 'a | b'
@@ -212,20 +229,20 @@ class test_parser(unittest.TestCase):
         self.assertASTEquals(s,
             commandnode(s,
               wordnode(s, s, [
-                comsubnode(s,
+                comsubnode(s, [
                     commandnode('$<$(a) b',
                         wordnode('$'),
                         redirectnode('<$(a)', None, '<',
                           wordnode('$(a)', '$(a)', [
-                            comsubnode('$(a)',
+                            comsubnode('$(a)', [
                                 commandnode('a',
                                     wordnode('a'))
-                            )
+                            ])
                           ])
                         ),
                         wordnode('b'),
                     )
-                )
+                ])
               ])
             )
         )
@@ -264,17 +281,17 @@ class test_parser(unittest.TestCase):
             commandnode(s,
               wordnode('a'),
               wordnode('<(b $(c))', '<(b $(c))', [
-                procsubnode('<(b $(c))',
+                procsubnode('<(b $(c))', [
                   commandnode('b $(c)',
                     wordnode('b'),
                     wordnode('$(c)', '$(c)', [
-                      comsubnode('$(c)',
+                      comsubnode('$(c)', [
                           commandnode('c',
                               wordnode('c'))
-                      )]
+                      ])]
                     )
                   )
-                )
+                ])
               ])
             )
         )
@@ -284,16 +301,16 @@ class test_parser(unittest.TestCase):
             commandnode(s,
                 wordnode('a'),
                 wordnode('`b`', '`b`', [
-                    comsubnode('`b`',
+                    comsubnode('`b`', [
                         commandnode('b',
                             wordnode('b'))
-                    ),
+                    ]),
                 ]),
                 wordnode('`c`', '"`c`"', [
-                    comsubnode('`c`',
+                    comsubnode('`c`', [
                         commandnode('c',
                             wordnode('c'))
-                    ),
+                    ]),
                 ]),
                 wordnode('`c`', "'`c`'")
             )
@@ -698,22 +715,22 @@ class test_parser(unittest.TestCase):
                 commandnode(s,
                   wordnode("$(a)", "'$(a)'"),
                   wordnode("$(b)", '"$(b)"', [
-                      comsubnode("$(b)",
+                      comsubnode("$(b)", [
                         commandnode("b", wordnode("b"))
-                      )
+                      ])
                   ])))
 
         s = "\"$(a \"b\" 'c')\" '$(a \"b\" 'c')'"
         self.assertASTEquals(s,
                 commandnode(s,
                   wordnode("$(a \"b\" 'c')", "\"$(a \"b\" 'c')\"", [
-                      comsubnode("$(a \"b\" 'c')",
+                      comsubnode("$(a \"b\" 'c')", [
                           commandnode("a \"b\" 'c'",
                               wordnode('a'),
                               wordnode('b', '"b"'),
                               wordnode('c', "'c'")
                           )
-                      )
+                      ])
                   ]),
                   wordnode("$(a \"b\" 'c')", "'$(a \"b\" 'c')'")
                 ))
@@ -779,10 +796,10 @@ class test_parser(unittest.TestCase):
                   wordnode('a', 'a'),
                   redirectnode('<<<$(b)', None, '<<<',
                     wordnode('$(b)', '$(b)', [
-                      comsubnode('$(b)',
+                      comsubnode('$(b)', [
                         commandnode('b',
                           wordnode('b'))
-                      )
+                      ])
                     ])
                   )
                 )
@@ -797,9 +814,9 @@ class test_parser(unittest.TestCase):
                               wordnode('a'),
                               reservedwordnode('in', 'in'),
                               wordnode('$(b)c', '$(b)"c"', [
-                                comsubnode('$(b)',
+                                comsubnode('$(b)', [
                                   commandnode('b', wordnode('b'))
-                                )
+                                ])
                               ]),
                               reservedwordnode(';', ';'),
                               reservedwordnode('do', 'do'),
@@ -869,11 +886,11 @@ class test_parser(unittest.TestCase):
         self.assertASTEquals(s,
                              commandnode(s,
                                assignmentnode('a=$(b)', 'a=$(b)', [
-                                comsubnode('$(b)',
+                                comsubnode('$(b)', [
                                   commandnode('b',
                                     wordnode('b'),
                                   )
-                                )
+                                ])
                                ]),
                                wordnode('c'),
                              )
@@ -883,11 +900,11 @@ class test_parser(unittest.TestCase):
         self.assertASTEquals(s,
                              commandnode(s,
                                assignmentnode('a=$(b) $c', 'a="$(b) $c"', [
-                                comsubnode('$(b)',
+                                comsubnode('$(b)', [
                                   commandnode('b',
                                     wordnode('b'),
                                   )
-                                ),
+                                ]),
                                 parameternode('c', '$c')
                                ]),
                                wordnode('d'),
@@ -929,12 +946,12 @@ class test_parser(unittest.TestCase):
                 commandnode(s,
                   wordnode('a'),
                   wordnode('$(b $(c $(d $(e))))', '$(b $(c $(d $(e))))', [
-                    comsubnode('$(b $(c $(d $(e))))',
+                    comsubnode('$(b $(c $(d $(e))))', [
                       commandnode('b $(c $(d $(e)))',
                         wordnode('b'),
                         wordnode('$(c $(d $(e)))')
                       )
-                    )
+                    ])
                   ])
                 ),
                 expansionlimit=1
@@ -950,18 +967,18 @@ class test_parser(unittest.TestCase):
                 commandnode(s,
                   wordnode('a'),
                   wordnode('$(b $(c))', '$(b $(c))', [
-                    comsubnode('$(b $(c))',
+                    comsubnode('$(b $(c))', [
                       commandnode('b $(c)',
                         wordnode('b'),
                         wordnode('$(c)', '$(c)', [
-                          comsubnode('$(c)',
+                          comsubnode('$(c)', [
                             commandnode('c',
                               wordnode('c')
                             )
-                          )
+                          ])
                         ])
                       )
-                    )
+                    ])
                   ])
                 ),
                 expansionlimit=i
@@ -974,11 +991,11 @@ class test_parser(unittest.TestCase):
             commandnode(s,
               wordnode('a'),
               wordnode('$(b)c $1', '"$(b)"c" $1"', [
-                comsubnode('$(b)',
+                comsubnode('$(b)', [
                   commandnode('b',
                     wordnode('b'),
                   )
-                ),
+                ]),
                 parameternode('1', '$1'),
               ])
             ),
@@ -1069,15 +1086,24 @@ class test_parser(unittest.TestCase):
         self.assertASTEquals(s,
                           commandnode('$(a;b)',
                           wordnode('$(a;b)', '$(a;b)', [
-                            comsubnode('$(a;b)',
+                            comsubnode('$(a;b)', [
                               listnode('a;b',
                                   commandnode('a', wordnode('a'),),
                                   operatornode(';', ';'),
                                   commandnode('b', wordnode('b'),),
-                                )),
+                                ),
+                            ])
                           ]),
                         )
                         )
+
+    def test_comments(self):
+        s = '# \n a #comment'
+        self.assertASTEquals(s,
+                             commandnode('a',
+                                wordnode('a'),
+                             )
+                            )
 
     def test_parameter_braces(self):
         return
@@ -1089,11 +1115,11 @@ class test_parser(unittest.TestCase):
             commandnode(s,
               wordnode('a'),
               wordnode('$(b)c $1', '"$(b)"c" $1"', [
-                comsubnode('$(b)',
+                comsubnode('$(b)', [
                   commandnode('b',
                     wordnode('b'),
                   )
-                ),
+                ]),
                 parameternode('1', '$1'),
               ])
             ),


### PR DESCRIPTION
Allows to parse whole files.

The idea is that I force-reduce on inputunit -> NEWLINE rule and accept by creating a dummy newline node that only retains position (needed for further parsing). These nodes are filtered in the end to prevent output such as:
NewlineNode
NewlineNode
CommandNode
...

I handpicked the relevant changes, so I hope I didn't miss anything.
