### PR TITLE
Make test files directly runnable

### DIFF
--- a/tests/test-parser.py
+++ b/tests/test-parser.py
@@ -1098,3 +1098,6 @@ class test_parser(unittest.TestCase):
               ])
             ),
         )
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test-tokenizer.py
+++ b/tests/test-tokenizer.py
@@ -328,3 +328,6 @@ class test_tokenizer(unittest.TestCase):
                           t(tt.WORD, 'a', [0, 1]),
                           t(tt.WORD, "'b  '", [2, 7], set([flags.word.QUOTED])),
                           t(tt.WORD, 'c', [8, 9])])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This makes it possible to run tests using, for example:

    python tests/test-tokenizer.py

See https://docs.python.org/2/library/unittest.html#basic-example

I'm not too familiar with Python testing, so I couldn't figure out how
to run the tests any other way. Let me know if there's something I
should be doing instead of this.