### PR TITLE
add full support for both Py2 and Py3 (ref #7)

### DIFF
--- a/bashlex/__init__.py
+++ b/bashlex/__init__.py
@@ -1,4 +1,4 @@
-from . import parser, tokenizer
+from bashlex import parser, tokenizer
 
 parse = parser.parse
 parsesingle = parser.parsesingle

--- a/bashlex/state.py
+++ b/bashlex/state.py
@@ -1,3 +1,3 @@
-from . import flags, utils
+from bashlex import flags, utils
 
 parserstate = lambda: utils.typedset(flags.parser)

--- a/bashlex/tokenizer.py
+++ b/bashlex/tokenizer.py
@@ -168,6 +168,8 @@ class token(object):
     def __nonzero__(self):
         return not (self.ttype is None and self.value is None)
 
+    __bool__ = __nonzero__
+
     def __eq__(self, other):
         return isinstance(other, token) and (self.type == other.type and
                                              self.value == other.value and

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from setuptools import setup
+try:
+    from setuptools import setup #Py2
+except ImportError:
+    from distutils.core import setup #Py3
 
 setup(
     name='bashlex',

--- a/tests/test-parser.py
+++ b/tests/test-parser.py
@@ -945,7 +945,7 @@ class test_parser(unittest.TestCase):
             parser._parser = old
 
         s = 'a $(b $(c))'
-        for i in [None] + range(2, 5):
+        for i in [None] + list(range(2, 5)):
             self.assertASTEquals(s,
                 commandnode(s,
                   wordnode('a'),


### PR DESCRIPTION
Hi, this should fix bashlex to work with both Python 2 and Python 3.
I have been successfully using it for several months now.

Changes:
* switched 'from . import' for a more specific 'from bashlex import'
* range returns an iterator instead of a list in Py3
* setuptools has different imports for Py2 and Py3

* __nonzero__ in Py3 is __bool__
a consequence of this was that Py2 would return True and Py3 False for `not token(None,None)`
and e.g. '!' would get parsed as 'word' instead of a 'bang'

* fix 'hack' table to derive states dynamically
the states which need fixing by the 'hack' are different for different Python versions and even differ
on Windows vs. Linux, so I derive them dynamically from the state 0