### PR TITLE
Make tests more portable and cleaner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 tests:
-	@which nosetests 2>&1 >/dev/null || echo "error: nosetests missing, run 'pip install nose'\n"
+	@which nosetests >/dev/null 2>&1 || echo "error: nosetests missing, run 'pip install nose'\n"
 	nosetests --with-doctest tests/ bashlex/
 
 .PHONY: tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 tests:
-	@python -c "import nose" >/dev/null 2>&1 || echo "error: nose missing, run 'pip install nose'\n"
+	@python -c "import nose" >/dev/null 2>&1 || (echo "error: nose missing, run 'pip install nose'\n" && false)
 	python -m nose --with-doctest
 
 .PHONY: tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 tests:
-	@which nosetests >/dev/null 2>&1 || echo "error: nosetests missing, run 'pip install nose'\n"
-	nosetests --with-doctest tests/ bashlex/
+	@python -c "import nose" >/dev/null 2>&1 || echo "error: nose missing, run 'pip install nose'\n"
+	python -m nose --with-doctest
 
 .PHONY: tests


### PR DESCRIPTION
This makes a few changes to the Makefile:

1. Actually redirect stderr to /dev/null
2. Run nose through python, not directly (helps with multiple python versions)
3. Don't try to run tests if nose is missing

The commit messages have a few more details, but let me know if I should explain further. Thanks!