### PR TITLE
Add basic .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - 2.7.12
+  - 3.5
+install:
+  - pip install -U nose -r requirements.txt
+  - python setup.py install
+script:
+  - make tests


### PR DESCRIPTION
Hi @idank, would you be interested in using [Travis CI](https://travis-ci.org/) to automatically run tests every time a commit is pushed, helping ensure that the tests don't accidentally break? Here's an example of what this would look like: https://travis-ci.org/josephfrazier/bashlex/builds/177164810 

As you can see, the tests pass on Python 2.7.12, but not yet on Python 3.5 (https://github.com/idank/bashlex/pull/15 should fix this).

See https://docs.travis-ci.com/user/languages/python/ for more information about the `.travis.yml` format.

Cheers!