### PR TITLE
tokenizer: remove unused COND_ERROR

### DIFF
--- a/bashlex/tokenizer.py
+++ b/bashlex/tokenizer.py
@@ -47,7 +47,8 @@ class tokentype(enum.Enum):
     COPROC = 15
     COND_START = 16
     COND_END = 17
-    COND_ERROR = 18
+    # https://github.com/idank/bashlex/issues/20
+    # COND_ERROR = 18
     IN = 19
     BANG = '!'
     TIME = 21


### PR DESCRIPTION
This fixes https://github.com/idank/bashlex/issues/20, as can be shown
by comparing the output of the following command before/after this
change:

    rm bashlex/parsetab.py*; make tests