### PR TITLE
Require enum34 only for python<3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ See https://github.com/idank/bashlex/blob/master/README.md for more info.''',
         'Topic :: System :: System Shells',
         'Topic :: Text Processing',
     ],
-    install_requires=['enum34'],
+    install_requires=[
+        'enum34;python_version<"3.4"'
+    ],
     packages=['bashlex'],
     data_files = [('', ['LICENSE'])]
 )


### PR DESCRIPTION
As suggested for this exact use case here:
https://stackoverflow.com/a/32643122/4935114