### PR TITLE
Elif clause

### DIFF
--- a/bashlex/parser.py
+++ b/bashlex/parser.py
@@ -360,6 +360,8 @@ def p_elif_clause(p):
     for i in range(1, len(p)):
         if isinstance(p[i], ast.node):
             parts.append(p[i])
+        elif isinstance(p[i], list): 
+            parts.extend(p[i])
         else:
             parts.append(ast.node(kind='reservedword', word=p[i], pos=p.lexspan(i)))
     p[0] = parts

--- a/bashlex/tokenizer.py
+++ b/bashlex/tokenizer.py
@@ -970,7 +970,7 @@ class tokenizer(object):
         c = value[0]
 
         def legalvariablechar(x):
-            return x.isalpha() or x == '_'
+            return x.isalnum() or x == '_'
 
         if not legalvariablechar(c):
             return

--- a/bashlex/tokenizer.py
+++ b/bashlex/tokenizer.py
@@ -968,12 +968,15 @@ class tokenizer(object):
 
     def _is_assignment(self, value, iscompassign):
         c = value[0]
+        
+        def legalvariablestarter(x):
+            return x.isalpha()
 
         def legalvariablechar(x):
             return x.isalnum() or x == '_'
 
-        if not legalvariablechar(c):
-            return
+        if not legalvariablestarter(c):
+            return False
 
         for i, c in enumerate(value):
             if c == '=':

--- a/tests/test-tokenizer.py
+++ b/tests/test-tokenizer.py
@@ -331,3 +331,14 @@ class test_tokenizer(unittest.TestCase):
                           t(tt.WORD, 'a', [0, 1]),
                           t(tt.WORD, "'b  '", [2, 7], set([flags.word.QUOTED])),
                           t(tt.WORD, 'c', [8, 9])])
+
+    def test_variables(self):
+        s = 'a0_=b'
+        self.assertTokens(s, [
+                          t(tt.ASSIGNMENT_WORD, 'a0_=b', [0, 5],
+                            flags=set([flags.word.NOSPLIT, flags.word.ASSIGNMENT]))])
+
+        s = 'a0_+=b'
+        self.assertTokens(s, [
+                          t(tt.ASSIGNMENT_WORD, 'a0_+=b', [0, 6],
+                            flags=set([flags.word.NOSPLIT, flags.word.ASSIGNMENT]))])


### PR DESCRIPTION
I proposed a fix for `elif clause` when there more than 2 `elif` clauses. Here is the problem, considering if else clause below:

```
if [ -f /cond1 ];
then
  cmd1;
elif [ -f /cond2 ];
then
  cmd2;
elif [ -f /cond3 ];
then
 cmd3;
else
 cmd4;
fi
```

Parsed result before fix, elif clause is wrongly added as word because it was list not a node:

```
CompoundNode(list=[
  IfNode(pos=(0, 104), parts=[
    ReservedwordNode(pos=(0, 2), word='if'),
    ListNode(pos=(3, 17), parts=[
        CommandNode(pos=(3, 16), parts=[
          WordNode(pos=(3, 4), word='['),
          WordNode(pos=(5, 7), word='-f'),
          WordNode(pos=(8, 14), word='/cond1'),
          WordNode(pos=(15, 16), word=']'),
        ]),
        OperatorNode(op=';', pos=(16, 17)),
      ]),
    ReservedwordNode(pos=(18, 22), word='then'),
    ListNode(pos=(23, 28), parts=[
        CommandNode(pos=(23, 27), parts=[
          WordNode(pos=(23, 27), word='cmd1'),
        ]),
        OperatorNode(op=';', pos=(27, 28)),
      ]),
    ReservedwordNode(pos=(29, 33), word='elif'),
    ListNode(pos=(34, 48), parts=[
        CommandNode(pos=(34, 47), parts=[
          WordNode(pos=(34, 35), word='['),
          WordNode(pos=(36, 38), word='-f'),
          WordNode(pos=(39, 45), word='/cond2'),
          WordNode(pos=(46, 47), word=']'),
        ]),
        OperatorNode(op=';', pos=(47, 48)),
      ]),
    ReservedwordNode(pos=(49, 53), word='then'),
    ListNode(pos=(54, 59), parts=[
        CommandNode(pos=(54, 58), parts=[
          WordNode(pos=(54, 58), word='cmd2'),
        ]),
        OperatorNode(op=';', pos=(58, 59)),
      ]),
    ReservedwordNode(pos=(0, 0), word=[
      ReservedwordNode(pos=(60, 64), word='elif'),
      ListNode(pos=(65, 79), parts=[
          CommandNode(pos=(65, 78), parts=[
            WordNode(pos=(65, 66), word='['),
            WordNode(pos=(67, 69), word='-f'),
            WordNode(pos=(70, 76), word='/cond3'),
            WordNode(pos=(77, 78), word=']'),
          ]),
          OperatorNode(op=';', pos=(78, 79)),
        ]),
      ReservedwordNode(pos=(80, 84), word='then'),
      ListNode(pos=(85, 90), parts=[
          CommandNode(pos=(85, 89), parts=[
            WordNode(pos=(85, 89), word='cmd3'),
          ]),
          OperatorNode(op=';', pos=(89, 90)),
        ]),
      ReservedwordNode(pos=(91, 95), word='else'),
      ListNode(pos=(96, 101), parts=[
          CommandNode(pos=(96, 100), parts=[
            WordNode(pos=(96, 100), word='cmd4'),
          ]),
          OperatorNode(op=';', pos=(100, 101)),
        ]),
    ]),
    ReservedwordNode(pos=(102, 104), word='fi'),
  ]),
], pos=(0, 104))
```

Parsed result after fix. The fix is to extend parts rather creating a new `ReservedWord`.

```
CompoundNode(list=[
  IfNode(pos=(0, 104), parts=[
    ReservedwordNode(pos=(0, 2), word='if'),
    ListNode(pos=(3, 17), parts=[
        CommandNode(pos=(3, 16), parts=[
          WordNode(pos=(3, 4), word='['),
          WordNode(pos=(5, 7), word='-f'),
          WordNode(pos=(8, 14), word='/cond1'),
          WordNode(pos=(15, 16), word=']'),
        ]),
        OperatorNode(op=';', pos=(16, 17)),
      ]),
    ReservedwordNode(pos=(18, 22), word='then'),
    ListNode(pos=(23, 28), parts=[
        CommandNode(pos=(23, 27), parts=[
          WordNode(pos=(23, 27), word='cmd1'),
        ]),
        OperatorNode(op=';', pos=(27, 28)),
      ]),
    ReservedwordNode(pos=(29, 33), word='elif'),
    ListNode(pos=(34, 48), parts=[
        CommandNode(pos=(34, 47), parts=[
          WordNode(pos=(34, 35), word='['),
          WordNode(pos=(36, 38), word='-f'),
          WordNode(pos=(39, 45), word='/cond2'),
          WordNode(pos=(46, 47), word=']'),
        ]),
        OperatorNode(op=';', pos=(47, 48)),
      ]),
    ReservedwordNode(pos=(49, 53), word='then'),
    ListNode(pos=(54, 59), parts=[
        CommandNode(pos=(54, 58), parts=[
          WordNode(pos=(54, 58), word='cmd2'),
        ]),
        OperatorNode(op=';', pos=(58, 59)),
      ]),
    ReservedwordNode(pos=(60, 64), word='elif'),
    ListNode(pos=(65, 79), parts=[
        CommandNode(pos=(65, 78), parts=[
          WordNode(pos=(65, 66), word='['),
          WordNode(pos=(67, 69), word='-f'),
          WordNode(pos=(70, 76), word='/cond3'),
          WordNode(pos=(77, 78), word=']'),
        ]),
        OperatorNode(op=';', pos=(78, 79)),
      ]),
    ReservedwordNode(pos=(80, 84), word='then'),
    ListNode(pos=(85, 90), parts=[
        CommandNode(pos=(85, 89), parts=[
          WordNode(pos=(85, 89), word='cmd3'),
        ]),
        OperatorNode(op=';', pos=(89, 90)),
      ]),
    ReservedwordNode(pos=(91, 95), word='else'),
    ListNode(pos=(96, 101), parts=[
        CommandNode(pos=(96, 100), parts=[
          WordNode(pos=(96, 100), word='cmd4'),
        ]),
        OperatorNode(op=';', pos=(100, 101)),
      ]),
    ReservedwordNode(pos=(102, 104), word='fi'),
  ]),
], pos=(0, 104))
```