### PR TITLE
Fix elif clause by extending parts to include previous elif parts

### DIFF
--- a/bashlex/parser.py
+++ b/bashlex/parser.py
@@ -360,6 +360,8 @@ def p_elif_clause(p):
     for i in range(1, len(p)):
         if isinstance(p[i], ast.node):
             parts.append(p[i])
+        elif isinstance(p[i], list):
+            parts.extend(p[i])
         else:
             parts.append(ast.node(kind='reservedword', word=p[i], pos=p.lexspan(i)))
     p[0] = parts


### PR DESCRIPTION
Last elif clause node is created and added to parts as a list.
When parsing the next elif (bottom-up order), as the last part is a list,
then it wrongly created a ReservedWord node and add the previous list as word.
The solution is to extend parts to include previous parts.