### PR TITLE
Fix import warnings on Python3

### DIFF
--- a/bashlex/utils.py
+++ b/bashlex/utils.py
@@ -1,6 +1,11 @@
-import collections
+try:
+    from collections.abc import MutableSet, Mapping
+except ImportError:
+    # Python 2 fallback
+    from collections import MutableSet, Mapping
 
-class typedset(collections.MutableSet):
+
+class typedset(MutableSet):
     def __init__(self, type_, iterable=[]):
         self._s = set()
         self._type = type_
@@ -48,7 +53,7 @@ class typedset(collections.MutableSet):
     def __repr__(self):
         return self._s.__repr__()
 
-class frozendict(collections.Mapping):
+class frozendict(Mapping):
     def __init__(self, *args, **kwargs):
         self.__dict = dict(*args, **kwargs)
         self.__hash = None


### PR DESCRIPTION
Lately I've been seeing these warnings in our tests on joerick/cibuildwheel

```
C:\Python37\lib\site-packages\bashlex\utils.py:3
  C:\Python37\lib\site-packages\bashlex\utils.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    class typedset(collections.MutableSet):
C:\Python37\lib\site-packages\bashlex\utils.py:51
  C:\Python37\lib\site-packages\bashlex\utils.py:51: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    class frozendict(collections.Mapping):
```

This PR updates the import, but keeps a fallback for Python 2 support.