### PR TITLE
chore: update setup and modernize a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bashlex/parsetab.py
 build/
 dist/
 bashlex.egg-info/
+*env*/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 tests:
-	@python -c "import nose" >/dev/null 2>&1 || (echo "error: nose missing, run 'pip install nose'\n" && false)
-	python -m nose --with-doctest
+	@python -c "import pytest" >/dev/null 2>&1 || (echo "error: pytest missing, run 'pip install pytest'\n" && false)
+	python -m pytest
 
 .PHONY: tests

--- a/README.md
+++ b/README.md
@@ -95,10 +95,18 @@ process/command substitutions.
 
 ## Releasing a new version
 
-- make tests
-- bump version in setup.py
+Suggestion for making a release environment:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+- `make tests`
+- bump version in `setup.py`
 - git tag the new commit
-- run`python setup.py bdist_egg sdist
+- run `python -m build`
 - run twine upload dist/*
 
 ## License

--- a/examples/commandsubstitution-remover.py
+++ b/examples/commandsubstitution-remover.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 
 import argparse
@@ -72,4 +74,4 @@ if __name__ == '__main__':
         # with the replacement string
         postprocessed[start:end] = args.replacement
 
-    print ''.join(postprocessed)
+    print(''.join(postprocessed))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-enum34
+enum34; python_version < "3.4"
+build
+twine
+pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal=1
+
+[tool:pytest]
+addopts = --doctest-modules -ra

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,5 @@
-try:
-    from setuptools import setup  #Py2
-except ImportError:
-    from distutils.core import setup  #Py3
+from setuptools import setup
 
-import sys
-
-install_requires = []
-if sys.version_info < (3, 4):
-    install_requires.append('enum34')
 
 setup(
     name='bashlex',
@@ -37,6 +29,7 @@ See https://github.com/idank/bashlex/blob/master/README.md for more info.''',
         'Topic :: System :: System Shells',
         'Topic :: Text Processing',
     ],
-    install_requires=install_requires,
+    python_requires=">=2.7, !=3.0, !=3.1, !=3.2, !=3.3, !=3.4",
+    install_requires=['enum34; python_version < "3.4"'],
     packages=['bashlex'],
 )


### PR DESCRIPTION
See #58. This is the "deluxe" package mentioned there. You could do a smaller set of changes, including just adding wheel to your environment and `python setup.py bdist_wheel —universal`. This includes:

* Add setup.cfg to always make a universal wheel (Python 2 + 3)
* Add pyproject.toml to support PEP 517 builds
* Update docs on how to build using PyPA build (still can build classically as well, of course)
* Update setup.py for best practices (including missing python_requires, and proper environment markers for install_requires)
* Replace nose (abandoned since 2015) with pytest (which can run nose tests)
* Minor fix for Python 3 incompatible syntax
