### PR TITLE
yacc: fixed newline bug (fixes #47)

### DIFF
--- a/bashlex/yacc.py
+++ b/bashlex/yacc.py
@@ -341,6 +341,10 @@ class LRParser:
         sym.type = "$end"
         symstack.append(sym)
         state = 0
+        # get number assignment to newline action
+        # cannot hardcode as python2 and python3 produce different
+        # numbers
+        newline = actions[state].get('NEWLINE')
         while 1:
             # Get the next symbol on the input.  If a lookahead symbol
             # is already set, we just use that. Otherwise, we'll pull
@@ -371,10 +375,14 @@ class LRParser:
 
             if t is not None:
                 if t > 0:
-                    # shift a symbol on the stack
-                    statestack.append(t)
-                    state = t
-                    
+                    if t == newline and state == 0:
+                        # If in init state and \n is encountered, then shift the \n off the stack and continue
+                        # The shift off the stack is accomplished by just never adding it in the first place
+                        state = 0
+                    else:
+                        # shift a symbol on the stack
+                        statestack.append(t)
+                        state = t
                     # --! DEBUG
                     debug.debug("Action : Shift and goto state %s", t)
                     # --! DEBUG
@@ -660,6 +668,11 @@ class LRParser:
         sym.type = '$end'
         symstack.append(sym)
         state = 0
+
+        # get number assignment to newline action
+        # cannot hardcode as python2 and python3 produce different
+        # numbers
+        newline = actions[state].get('NEWLINE')
         while 1:
             # Get the next symbol on the input.  If a lookahead symbol
             # is already set, we just use that. Otherwise, we'll pull
@@ -680,9 +693,14 @@ class LRParser:
 
             if t is not None:
                 if t > 0:
-                    # shift a symbol on the stack
-                    statestack.append(t)
-                    state = t
+                    if t == newline and state == 0:
+                        # If in init state and \n is encountered, then shift the \n off the stack and continue
+                        # The shift off the stack is accomplished by just never adding it in the first place
+                        state = 0
+                    else:
+                        # shift a symbol on the stack
+                        statestack.append(t)
+                        state = t
 
                     symstack.append(lookahead)
                     lookahead = None
@@ -936,6 +954,11 @@ class LRParser:
         sym.type = '$end'
         symstack.append(sym)
         state = 0
+        
+        # get number assignment to newline action
+        # cannot hardcode as python2 and python3 produce different
+        # numbers
+        newline = actions[state].get('NEWLINE')
         while 1:
             # Get the next symbol on the input.  If a lookahead symbol
             # is already set, we just use that. Otherwise, we'll pull
@@ -956,9 +979,14 @@ class LRParser:
 
             if t is not None:
                 if t > 0:
-                    # shift a symbol on the stack
-                    statestack.append(t)
-                    state = t
+                    if t == newline and state == 0:
+                        # If in init state and \n is encountered, then shift the \n off the stack and continue
+                        # The shift off the stack is accomplished by just never adding it in the first place
+                        state = 0
+                    else:
+                        # shift a symbol on the stack
+                        statestack.append(t)
+                        state = t
 
                     symstack.append(lookahead)
                     lookahead = None


### PR DESCRIPTION
This adds support for all the errors outlined in issue #47. This also fixes issues: #1, #2, #23, #32, and #55. Just added the edge case into yacc. Adding it to the grammar or to the tokenizer ends up being a lot of work than adding it directly to yacc (in both cases you need to add it to a lot of different edge situations versus basically just ignoring the token in yacc.py)