### PR TITLE
Add hash method to node class

### DIFF
--- a/bashlex/ast.py
+++ b/bashlex/ast.py
@@ -24,6 +24,9 @@ class node(object):
         if not isinstance(other, node):
             return False
         return self.__dict__ == other.__dict__
+    
+    def __hash__(self):
+        return hash(tuple(sorted(self.__dict__)))
 
 class nodevisitor(object):
     def _visitnode(self, n, *args, **kwargs):


### PR DESCRIPTION
The class node is essentially a wrapper around a dict.

Adding a hash method makes it compatible with a lot of data structures (e.g. set).