### PR TITLE
fix backslash newline and multiple newlines at end

### DIFF
--- a/bashlex/tokenizer.py
+++ b/bashlex/tokenizer.py
@@ -1042,6 +1042,8 @@ class tokenizer(object):
 
             if c == '\\' and remove_quoted_newline and self._shell_input_line[self._shell_input_line_index] == '\n':
                 self._line_number += 1
+                # skip past the newline
+                self._shell_input_line_index += 1
                 continue
             else:
                 return c

--- a/bashlex/yacc.py
+++ b/bashlex/yacc.py
@@ -364,7 +364,11 @@ class LRParser:
                 debug.debug('Stack  : %s',
                             ('%s . %s' % (' '.join([xx.type for xx in symstack][1:]), str(lookahead))).lstrip())
 
-            
+            if state == 0 and ltype == '$end' and all([xx.type == 'NEWLINE' for xx in symstack[1:]]):
+                # we're at the end and everything else is a newline
+                # so we're going to return
+                # fixes multiple newlines at end
+                t = 0
             if t is not None:
                 if t > 0:
                     if t == newline and state == 0:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1103,3 +1103,29 @@ class test_parser(unittest.TestCase):
               ])
             ),
         )
+
+    def test_backslash_newline(self):
+      s = 'for hook in \\\n\t/etc/* \\\n\t/lib/* \\\n\t/asdf/*\ndo\n\techo hook\ndone'
+      self.assertASTEquals(s,
+                  compoundnode(s, fornode(s,
+                    reservedwordnode('for', 'for'),
+                    wordnode('hook','hook'),
+                    reservedwordnode('in','in'),
+                    wordnode('/etc/*','/etc/*'),
+                    wordnode('/lib/*','/lib/*'),
+                    wordnode('/asdf/*','/asdf/*'),
+                    reservedwordnode('do', 'do'),
+                    commandnode('echo hook',
+                                wordnode('echo'),
+                                wordnode('hook')),
+                    reservedwordnode('done', 'done'),
+                                          )))
+      
+    def test_ending_newlines(self):
+      s = 'echo hello world\n\n\n'
+      self.assertASTEquals(s, commandnode(s.strip(), 
+                                                  wordnode('echo'),
+                                                  wordnode('hello'),
+                                                  wordnode('world')))
+      
+      


### PR DESCRIPTION
This PR fixes two active issues: #79 and #74.

It fixes the backslash newline issue by moving the tokenizer forward another index in the case that we see '\' followed by '\n'.

The second fix is a very specific one related to multiple newlines at the end of a file.

We fix this in yacc.py by explicitly checking for that condition.