### PR TITLE
tokenizer: fix backslash newline and multiple newlines at end 

### DIFF
--- a/bashlex/tokenizer.py
+++ b/bashlex/tokenizer.py
@@ -1042,6 +1042,8 @@ class tokenizer(object):
 
             if c == '\\' and remove_quoted_newline and self._shell_input_line[self._shell_input_line_index] == '\n':
                 self._line_number += 1
+                # skip past the newline
+                self._shell_input_line_index += 1
                 continue
             else:
                 return c

--- a/bashlex/yacc.py
+++ b/bashlex/yacc.py
@@ -364,7 +364,11 @@ class LRParser:
                 debug.debug('Stack  : %s',
                             ('%s . %s' % (' '.join([xx.type for xx in symstack][1:]), str(lookahead))).lstrip())
 
-            
+            if state == 0 and ltype == '$end' and all([xx.type == 'NEWLINE' for xx in symstack[1:]]):
+                # we're at the end and everything else is a newline
+                # so we're going to return
+                # fixes multiple newlines at end
+                t = 0
             if t is not None:
                 if t > 0:
                     if t == newline and state == 0:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1103,3 +1103,33 @@ class test_parser(unittest.TestCase):
               ])
             ),
         )
+
+    def test_backslash_newline(self):
+      s = """for hook in \\
+        /etc/* \\
+        /lib/* \\
+        /asdf/*
+      do
+        echo hook
+      done"""
+      self.assertASTEquals(s,
+                  compoundnode(s, fornode(s,
+                    reservedwordnode('for', 'for'),
+                    wordnode('hook','hook'),
+                    reservedwordnode('in','in'),
+                    wordnode('/etc/*','/etc/*'),
+                    wordnode('/lib/*','/lib/*'),
+                    wordnode('/asdf/*','/asdf/*'),
+                    reservedwordnode('do', 'do'),
+                    commandnode('echo hook',
+                                wordnode('echo'),
+                                wordnode('hook')),
+                    reservedwordnode('done', 'done'),
+                                          )))
+
+    def test_ending_newlines(self):
+      s = 'echo hello world\n\n\n'
+      self.assertASTEquals(s, commandnode(s.strip(),
+                                                  wordnode('echo'),
+                                                  wordnode('hello'),
+                                                  wordnode('world')))

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -345,3 +345,10 @@ class test_tokenizer(unittest.TestCase):
                           t(tt.WORD, 'a', [0, 1]),
                           t(tt.WORD, "'b  '", [2, 7], set([flags.word.QUOTED])),
                           t(tt.WORD, 'c', [8, 9])])
+
+    def test_escaped_newline(self):
+        s= """a \\\nb"""
+        self.assertTokens(s, [
+            t(tt.WORD, 'a', [0, 1]),
+            t(tt.WORD, 'b', [4, 5])
+        ])


### PR DESCRIPTION
I am reopening #80 which has been stale for a while with the changes requested by @idank. This PR like the previous one addresses two active issues: https://github.com/idank/bashlex/issues/74 and https://github.com/idank/bashlex/issues/79. I will be making further necessary changes if requested and will try to get these two issues resolved.